### PR TITLE
chore: align phpcs.xml.dist with shared baseline + reformat for WordPress-Extra

### DIFF
--- a/dashboard.php
+++ b/dashboard.php
@@ -1,95 +1,109 @@
 <?php
+/**
+ * Dashboard widgets for the ZuidWest Webapp plugin.
+ *
+ * @package ZuidWestWebapp
+ */
 
-defined('ABSPATH') || exit;
+defined( 'ABSPATH' ) || exit;
 
-function zw_webapp_add_dashboard_widgets(): void
-{
-    wp_add_dashboard_widget(
-        'zw_webapp_dashboard_recent_pushes',
-        'ZuidWest Webapp',
-        'zw_webapp_dashboard_widget_display'
-    );
+/**
+ * Registers the recent-pushed-posts dashboard widget.
+ *
+ * @return void
+ */
+function zw_webapp_add_dashboard_widgets(): void {
+	wp_add_dashboard_widget(
+		'zw_webapp_dashboard_recent_pushes',
+		'ZuidWest Webapp',
+		'zw_webapp_dashboard_widget_display'
+	);
 }
-add_action('wp_dashboard_setup', 'zw_webapp_add_dashboard_widgets');
+add_action( 'wp_dashboard_setup', 'zw_webapp_add_dashboard_widgets' );
 
-function zw_webapp_dashboard_widget_display(): void
-{
-    // Recent Pushed Articles
-    $args = array(
-        'post_type' => 'post',
-        'posts_per_page' => 5,
-        'no_found_rows' => true,
-        'update_post_term_cache' => false,
-        'meta_query' => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Used in production with no issues
-            array(
-                'key' => 'push_sent',
-                'value' => '1',
-                'compare' => '='
-            )
-        ),
-        'orderby' => 'date',
-        'order' => 'DESC'
-    );
-    $recent_pushed_posts = new WP_Query($args);
+/**
+ * Renders the recent-pushed-posts dashboard widget.
+ *
+ * @return void
+ */
+function zw_webapp_dashboard_widget_display(): void {
+	// Recent Pushed Articles.
+	$args                = array(
+		'post_type'              => 'post',
+		'posts_per_page'         => 5,
+		'no_found_rows'          => true,
+		'update_post_term_cache' => false,
+		'meta_query'             => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Used in production with no issues.
+			array(
+				'key'     => 'push_sent',
+				'value'   => '1',
+				'compare' => '=',
+			),
+		),
+		'orderby'                => 'date',
+		'order'                  => 'DESC',
+	);
+	$recent_pushed_posts = new WP_Query( $args );
 
-    echo '<div id="published-posts" class="activity-block">';
+	echo '<div id="published-posts" class="activity-block">';
 
-    echo '<h3>Recent gepusht</h3>';
+	echo '<h3>Recent gepusht</h3>';
 
-    if ($recent_pushed_posts->have_posts()) {
-        echo '<ul>';
+	if ( $recent_pushed_posts->have_posts() ) {
+		echo '<ul>';
 
-        while ($recent_pushed_posts->have_posts()) {
-            $recent_pushed_posts->the_post();
+		while ( $recent_pushed_posts->have_posts() ) {
+			$recent_pushed_posts->the_post();
 
-            $time = get_the_time('U');
-            $formatted_date_time = date_i18n('j M, H:i', $time);
-            $post_edit_link = get_edit_post_link();
-            $post_title = get_the_title();
+			$time                = get_the_time( 'U' );
+			$formatted_date_time = date_i18n( 'j M, H:i', $time );
+			$post_edit_link      = get_edit_post_link();
+			$post_title          = get_the_title();
 
-            printf(
-                '<li><span>%1$s</span> <a href="%2$s">%3$s</a></li>',
-                esc_html($formatted_date_time),
-                esc_url($post_edit_link),
-                esc_html($post_title)
-            );
-        }
+			printf(
+				'<li><span>%1$s</span> <a href="%2$s">%3$s</a></li>',
+				esc_html( $formatted_date_time ),
+				esc_url( $post_edit_link ),
+				esc_html( $post_title )
+			);
+		}
 
-        echo '</ul>';
-    } else {
-        echo '<p>Er zijn recent geen artikelen gepusht.</p>';
-    }
+		echo '</ul>';
+	} else {
+		echo '<p>Er zijn recent geen artikelen gepusht.</p>';
+	}
 
-	// Nitpicking
-    echo '<style>
+	// Nitpicking.
+	echo '<style>
             #zw_webapp_dashboard_recent_pushes .inside { margin: 0; padding-bottom: 0; }
           </style>';
 
-    echo '</div>';
+	echo '</div>';
 
-	// Push Count
+	// Push Count.
 	$daily_push_count = zw_webapp_get_daily_push_count();
 	echo '<div id="zw-webapp-daily-push-count">';
 	echo '<h3 style="margin-bottom: 15px;">Gepushte artikelen per dag</h3>';
 
-	if (!empty($daily_push_count)) {
-	    echo '<ul style="display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 10px; list-style: none; padding: 0;">';
+	if ( ! empty( $daily_push_count ) ) {
+		// phpcs:ignore Generic.Files.LineLength.TooLong -- Inline CSS for the dashboard widget grid layout.
+		echo '<ul style="display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 10px; list-style: none; padding: 0;">';
 
-	    foreach ($daily_push_count as $date => $count) {
-	        $formatted_date = date_i18n('j M', strtotime($date));
-	        // Check if the count is 1 to decide between 'push' and 'pushes'
-	        $push_text = $count == 1 ? 'push' : 'pushes';
-	        printf(
-	            '<li style="background-color: #f7f7f7; padding: 8px; border-radius: 5px; box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);"><span>%1$s: %2$s %3$s</span></li>',
-	            esc_html($formatted_date),
-	            esc_html($count),
-	            esc_html($push_text)
-	        );
-	    }
+		foreach ( $daily_push_count as $date => $count ) {
+			$formatted_date = date_i18n( 'j M', strtotime( $date ) );
+			// Check if the count is 1 to decide between 'push' and 'pushes'.
+			$push_text = 1 === $count ? 'push' : 'pushes';
+			printf(
+				'<li style="background-color: #f7f7f7; padding: 8px; border-radius: 5px; box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);"><span>%1$s: %2$s %3$s</span></li>',
+				esc_html( $formatted_date ),
+				esc_html( $count ),
+				esc_html( $push_text )
+			);
+		}
 
-	    echo '</ul>';
+		echo '</ul>';
 	} else {
-	    echo '<p>Geen data over pushberichten beschikbaar.</p>';
+		echo '<p>Geen data over pushberichten beschikbaar.</p>';
 	}
 	echo '</div>';
 

--- a/frontend.php
+++ b/frontend.php
@@ -1,38 +1,46 @@
 <?php
-
 /**
- * Add link to the Manifest in the theme.
+ * Adds the Progressier manifest link and head tags to the frontend.
+ *
+ * @package ZuidWestWebapp
  */
 
-defined('ABSPATH') || exit;
+defined( 'ABSPATH' ) || exit;
 
-add_action('wp_enqueue_scripts', 'zw_webapp_enqueue_scripts');
-add_action('wp_head', 'zw_webapp_head_tags');
+add_action( 'wp_enqueue_scripts', 'zw_webapp_enqueue_scripts' );
+add_action( 'wp_head', 'zw_webapp_head_tags' );
 
-function zw_webapp_enqueue_scripts(): void
-{
-    $webapp_settings = get_option('zw_webapp_settings');
+/**
+ * Enqueues the Progressier script when the plugin is configured.
+ *
+ * @return void
+ */
+function zw_webapp_enqueue_scripts(): void {
+	$webapp_settings = get_option( 'zw_webapp_settings' );
 
-    if (!empty($webapp_settings['progressier_id'])) {
-        $base_url = 'https://progressier.app/' . $webapp_settings['progressier_id'];
+	if ( ! empty( $webapp_settings['progressier_id'] ) ) {
+		$base_url = 'https://progressier.app/' . $webapp_settings['progressier_id'];
 
-        // phpcs:disable WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion
-        wp_enqueue_script('progressier', $base_url . '/script.js', [], false, ['strategy' => 'defer']);
-        // phpcs:enable
-    }
+		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion -- External Progressier script, version not controlled by us.
+		wp_enqueue_script( 'progressier', $base_url . '/script.js', array(), false, array( 'strategy' => 'defer' ) );
+	}
 }
 
-function zw_webapp_head_tags(): void
-{
-    $webapp_settings = get_option('zw_webapp_settings');
+/**
+ * Outputs the Progressier manifest link and theme-color meta tag in the document head.
+ *
+ * @return void
+ */
+function zw_webapp_head_tags(): void {
+	$webapp_settings = get_option( 'zw_webapp_settings' );
 
-    if (!empty($webapp_settings['progressier_id'])) {
-        $base_url = 'https://progressier.app/' . $webapp_settings['progressier_id'];
-        echo '<link rel="manifest" href="' . esc_url($base_url . '/progressier.json') . '"/>' . "\n";
-    }
+	if ( ! empty( $webapp_settings['progressier_id'] ) ) {
+		$base_url = 'https://progressier.app/' . $webapp_settings['progressier_id'];
+		echo '<link rel="manifest" href="' . esc_url( $base_url . '/progressier.json' ) . '"/>' . "\n";
+	}
 
-    // Check for required settings
-    if (!empty($webapp_settings['theme_color'])) {
-        echo '<meta name="theme-color" content="' . esc_attr($webapp_settings['theme_color']) . '"/>' . "\n";
-    }
+	// Check for required settings.
+	if ( ! empty( $webapp_settings['theme_color'] ) ) {
+		echo '<meta name="theme-color" content="' . esc_attr( $webapp_settings['theme_color'] ) . '"/>' . "\n";
+	}
 }

--- a/options.php
+++ b/options.php
@@ -1,140 +1,150 @@
 <?php
-
 /**
- * Add the options page to the WordPress menu.
+ * Settings page and options handling for the ZuidWest Webapp plugin.
+ *
+ * @package ZuidWestWebapp
  */
 
-defined('ABSPATH') || exit;
-
-function zw_webapp_add_admin_menu(): void
-{
-    add_options_page(
-        'ZuidWest Webapp',
-        'ZuidWest Webapp',
-        'manage_options',
-        'zw_webapp',
-        'zw_webapp_options_page'
-    );
-}
-add_action('admin_menu', 'zw_webapp_add_admin_menu');
+defined( 'ABSPATH' ) || exit;
 
 /**
- * Register settings for the webapp.
+ * Adds the plugin options page to the WordPress admin menu.
+ *
+ * @return void
  */
+function zw_webapp_add_admin_menu(): void {
+	add_options_page(
+		'ZuidWest Webapp',
+		'ZuidWest Webapp',
+		'manage_options',
+		'zw_webapp',
+		'zw_webapp_options_page'
+	);
+}
+add_action( 'admin_menu', 'zw_webapp_add_admin_menu' );
 
-defined('ABSPATH') || exit;
+/**
+ * Registers the plugin settings, section and fields.
+ *
+ * @return void
+ */
+function zw_webapp_settings_init(): void {
+	register_setting( 'pluginPage', 'zw_webapp_settings', array( 'sanitize_callback' => 'zw_webapp_validate_settings' ) );
 
-function zw_webapp_settings_init(): void
-{
-    register_setting('pluginPage', 'zw_webapp_settings', ['sanitize_callback' => 'zw_webapp_validate_settings']);
+	add_settings_section(
+		'zw_webapp_pluginPage_section',
+		__( 'ZuidWest Webapp Settings', 'zw-webapp' ),
+		'zw_webapp_settings_section_callback',
+		'pluginPage'
+	);
 
-    add_settings_section(
-        'zw_webapp_pluginPage_section',
-        __('ZuidWest Webapp Settings', 'zw-webapp'),
-        'zw_webapp_settings_section_callback',
-        'pluginPage'
-    );
+	// Fields for the settings.
+	$fields = array(
+		array( 'theme_color', __( 'Theme Color', 'zw-webapp' ) ),
+		array( 'progressier_id', __( 'Progressier ID', 'zw-webapp' ) ),
+		array( 'auth_token', __( 'Authorization Token', 'zw-webapp' ) ),
+		array( 'show_push_debug', __( 'Enable push debug', 'zw-webapp' ) ),
+	);
 
-    // Fields for the settings
-    $fields = [
-        ['theme_color', __('Theme Color', 'zw-webapp')],
-        ['progressier_id', __('Progressier ID', 'zw-webapp')],
-        ['auth_token', __('Authorization Token', 'zw-webapp')],
-        ['show_push_debug', __('Enable push debug', 'zw-webapp')]
-    ];
-
-    foreach ($fields as $field) {
-        add_settings_field(
-            $field[0],
-            $field[1],
-            'zw_webapp_settings_field_callback',
-            'pluginPage',
-            'zw_webapp_pluginPage_section',
-            ['id' => $field[0]]
-        );
-    }
+	foreach ( $fields as $field ) {
+		add_settings_field(
+			$field[0],
+			$field[1],
+			'zw_webapp_settings_field_callback',
+			'pluginPage',
+			'zw_webapp_pluginPage_section',
+			array( 'id' => $field[0] )
+		);
+	}
 }
 
-add_action('admin_init', 'zw_webapp_settings_init');
+add_action( 'admin_init', 'zw_webapp_settings_init' );
 
 /**
  * Callback to render each settings field.
- * @param array<string, mixed> $args
+ *
+ * @param array<string, mixed> $args Field arguments.
+ * @return void
  */
-function zw_webapp_settings_field_callback(array $args): void
-{
-    $options = get_option('zw_webapp_settings');
-    $field_value = isset($options[$args['id']]) ? esc_attr($options[$args['id']]) : '';
+function zw_webapp_settings_field_callback( array $args ): void {
+	$options     = get_option( 'zw_webapp_settings' );
+	$field_value = isset( $options[ $args['id'] ] ) ? esc_attr( $options[ $args['id'] ] ) : '';
 
-    switch ($args['id']) {
-        case 'theme_color':
-        case 'progressier_id':
-            echo sprintf('<input type="text" name="zw_webapp_settings[%s]" value="%s" autocomplete="off">', esc_attr($args['id']), esc_attr($field_value));
-            break;
+	switch ( $args['id'] ) {
+		case 'theme_color':
+		case 'progressier_id':
+			printf( '<input type="text" name="zw_webapp_settings[%s]" value="%s" autocomplete="off">', esc_attr( $args['id'] ), esc_attr( $field_value ) );
+			break;
 
-        case 'auth_token':
-            echo sprintf('<input type="password" name="zw_webapp_settings[%s]" value="%s" autocomplete="off">', esc_attr($args['id']), esc_attr($field_value));
-            break;
+		case 'auth_token':
+			printf( '<input type="password" name="zw_webapp_settings[%s]" value="%s" autocomplete="off">', esc_attr( $args['id'] ), esc_attr( $field_value ) );
+			break;
 
-        case 'show_push_debug':
-            $checked = $field_value ? 'checked' : '';
-            echo '<input type="checkbox" name="zw_webapp_settings[show_push_debug]" value="1" ' . esc_attr($checked) . ' autocomplete="off">';
-            break;
+		case 'show_push_debug':
+			$checked = $field_value ? 'checked' : '';
+			echo '<input type="checkbox" name="zw_webapp_settings[show_push_debug]" value="1" ' . esc_attr( $checked ) . ' autocomplete="off">';
+			break;
 
-        default:
-            echo 'Invalid settings field: ' . esc_html($args['id']);
-            break;
-    }
+		default:
+			echo 'Invalid settings field: ' . esc_html( $args['id'] );
+			break;
+	}
 }
 
-// Callback for settings section (can be expanded if needed)
-function zw_webapp_settings_section_callback(): void
-{
-    // This can contain any additional description or content for the settings section
-}
-
-// Options page rendering
-function zw_webapp_options_page(): void
-{
-    ?>
-    <form action='options.php' method='post'>
-        <h2>ZuidWest Webapp</h2>
-        <?php
-        settings_fields('pluginPage');
-        do_settings_sections('pluginPage');
-        submit_button();
-        ?>
-    </form>
-    <?php
-}
-
-// Validation for the settings
 /**
- * @param array<string, mixed> $value
- * @return array<string, mixed>
+ * Renders the settings section description (currently empty).
+ *
+ * @return void
  */
-function zw_webapp_validate_settings(array $value): array
-{
-    $old_value = get_option('zw_webapp_settings');
+function zw_webapp_settings_section_callback(): void {
+	// Reserved for future description text.
+}
 
-    // List of fields that should not be empty
-    $required_fields = ['theme_color', 'progressier_id', 'auth_token'];
+/**
+ * Renders the plugin options page.
+ *
+ * @return void
+ */
+function zw_webapp_options_page(): void {
+	?>
+	<form action='options.php' method='post'>
+		<h2>ZuidWest Webapp</h2>
+		<?php
+		settings_fields( 'pluginPage' );
+		do_settings_sections( 'pluginPage' );
+		submit_button();
+		?>
+	</form>
+	<?php
+}
 
-    foreach ($required_fields as $field) {
-        if (empty($value[$field])) {
-            // Add an error message to be displayed in the admin
-            add_settings_error(
-                'zw_webapp_settings',
-                $field . '_error',
-                sprintf('Error: %s cannot be empty.', $field),
-                'error'
-            );
+/**
+ * Validates the submitted settings; required fields fall back to the previous value.
+ *
+ * @param array<string, mixed> $value Submitted settings.
+ * @return array<string, mixed> Sanitised settings.
+ */
+function zw_webapp_validate_settings( array $value ): array {
+	$old_value = get_option( 'zw_webapp_settings' );
 
-            // Return the old value to prevent the new empty value from being saved
-            return $old_value;
-        }
-    }
+	// List of fields that should not be empty.
+	$required_fields = array( 'theme_color', 'progressier_id', 'auth_token' );
 
-    // If all fields are valid, return the sanitized value
-    return $value;
+	foreach ( $required_fields as $field ) {
+		if ( empty( $value[ $field ] ) ) {
+			// Add an error message to be displayed in the admin.
+			add_settings_error(
+				'zw_webapp_settings',
+				$field . '_error',
+				sprintf( 'Error: %s cannot be empty.', $field ),
+				'error'
+			);
+
+			// Return the old value to prevent the new empty value from being saved.
+			return $old_value;
+		}
+	}
+
+	// If all fields are valid, return the sanitised value.
+	return $value;
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,56 +1,52 @@
 <?xml version="1.0"?>
-<ruleset>
-    <arg name="extensions" value="php"/>
-    <arg name="colors"/>
+<ruleset name="zw-webapp">
+    <description>WordPress Coding Standards for ZuidWest Webapp.</description>
 
-    <!-- Ignore warnings, show progress of the run and show sniff names -->
-    <arg value="nps"/>
-
+    <!-- Files to scan -->
+    <file>zw-webapp.php</file>
+    <file>dashboard.php</file>
     <file>frontend.php</file>
     <file>options.php</file>
     <file>push.php</file>
-    <file>zw-webapp.php</file>
 
-    <!-- Fix crash on PHP 8 -->
-    <ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED"/>
+    <!-- Tooling -->
+    <arg name="extensions" value="php"/>
+    <arg name="colors"/>
+    <arg value="sp"/>
 
-    <rule ref="Generic.Files.EndFileNewline"/>
+    <ini name="error_reporting" value="E_ALL &amp; ~E_DEPRECATED"/>
 
-    <rule ref="PSR12">
-        <exclude name="PSR1.Files.SideEffects.FoundWithSymbols"/>
-        <exclude name="PSR12.Files.FileHeader.SpacingAfterBlock"/>
-        <exclude name="Generic.Files.LineLength.TooLong"/>
-        <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps"/>
+    <!-- Versions -->
+    <config name="testVersion" value="8.3-8.4"/>
+    <config name="minimum_wp_version" value="6.8"/>
+
+    <!-- Per-plugin -->
+    <config name="text_domain" value="zw-webapp"/>
+    <rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+        <properties>
+            <property name="prefixes" type="array">
+                <element value="zw_webapp"/>
+                <element value="ZW_WEBAPP"/>
+            </property>
+        </properties>
+    </rule>
+
+    <!-- Standards -->
+    <rule ref="WordPress-Extra">
+        <exclude name="Universal.Arrays.DisallowShortArraySyntax"/>
+    </rule>
+    <rule ref="WordPress-Docs">
+        <exclude name="Squiz.Commenting.FunctionComment.IncorrectTypeHint"/>
     </rule>
     <rule ref="PHPCompatibilityWP"/>
 
-    <!-- PHP and WordPress version requirements -->
-    <config name="testVersion" value="8.3-"/>
-    <config name="minimum_wp_version" value="6.4"/>
-
-    <rule ref="Squiz.Strings.DoubleQuoteUsage">
-
-    </rule>
-
-    <!-- WordPress -->
-    <rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+    <rule ref="Generic.Files.LineLength">
         <properties>
-            <property name="prefixes" type="array" value="zw_webapp_"/>
+            <property name="lineLimit" value="160"/>
+            <property name="absoluteLineLimit" value="0"/>
         </properties>
     </rule>
-    <rule ref="Generic.CodeAnalysis.EmptyPHPStatement"/>
-    <rule ref="WordPress.CodeAnalysis.EscapedNotTranslated"/>
-    <rule ref="WordPress.DB"/>
-    <rule ref="WordPress.DateTime"/>
-    <rule ref="WordPress.Security">
-        <exclude name="WordPress.Security.EscapeOutput.OutputNotEscaped"/>
-    </rule>
-    <rule ref="WordPress.Utils.I18nTextDomainFixer"/>
-    <rule ref="WordPress.PHP">
-        <exclude name="WordPress.PHP.YodaConditions"/>
-        <exclude name="Universal.Operators.DisallowShortTernary"/>
-    </rule>
-    <rule ref="WordPress.WP">
-        <exclude name="WordPress.DateTime.RestrictedFunctions"/>
-    </rule>
+
+    <exclude-pattern>vendor/*</exclude-pattern>
+    <exclude-pattern>node_modules/*</exclude-pattern>
 </ruleset>

--- a/push.php
+++ b/push.php
@@ -1,160 +1,199 @@
 <?php
+/**
+ * Push notification handling for the ZuidWest Webapp plugin.
+ *
+ * @package ZuidWestWebapp
+ */
 
-defined('ABSPATH') || exit;
+defined( 'ABSPATH' ) || exit;
 
-add_action('save_post', 'zw_webapp_schedule_push_notification', 20, 3);
-add_action('send_push_notification', 'zw_webapp_call_api');
-add_action('edit_form_top', 'zw_webapp_show_debug_message', 10, 1);
+add_action( 'save_post', 'zw_webapp_schedule_push_notification', 20, 3 );
+add_action( 'send_push_notification', 'zw_webapp_call_api' );
+add_action( 'edit_form_top', 'zw_webapp_show_debug_message', 10, 1 );
 
-function zw_webapp_schedule_push_notification(int $post_id, WP_Post $post, bool $update): void
-{
-    if (defined('WP_CLI') && WP_CLI) {
-        zw_webapp_set_debug_message($post_id, 'Not pushed - Refusing to push on cli-triggered actions');
-        return;
-    }
+/**
+ * Schedules a single push-notification cron event when a post is published.
+ *
+ * @param int     $post_id Post ID.
+ * @param WP_Post $post    Post object.
+ * @param bool    $update  Whether this is an update (unused, kept for hook signature).
+ * @return void
+ */
+function zw_webapp_schedule_push_notification( int $post_id, WP_Post $post, bool $update ): void {
+	unset( $update );
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		zw_webapp_set_debug_message( $post_id, 'Not pushed - Refusing to push on cli-triggered actions' );
+		return;
+	}
 
-    $send_push = false;
-    $send_push = apply_filters('zw_webapp_send_notification', $send_push, $post_id);
-    if (!$send_push) {
-        zw_webapp_set_debug_message($post_id, 'Not pushed - Filter zw_webapp_send_notification returned false, or was not hooked');
-        return;
-    }
+	$send_push = false;
+	$send_push = apply_filters( 'zw_webapp_send_notification', $send_push, $post_id );
+	if ( ! $send_push ) {
+		zw_webapp_set_debug_message( $post_id, 'Not pushed - Filter zw_webapp_send_notification returned false, or was not hooked' );
+		return;
+	}
 
-    if ($post->post_type !== 'post') {
-        zw_webapp_set_debug_message($post_id, 'Not pushed - Not a post');
-        return;
-    }
-    if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
-        zw_webapp_set_debug_message($post_id, 'Not pushed - Doing autosave');
-        return;
-    }
-    if (get_post_status($post_id) !== 'publish' || $post->post_status === 'trash') {
-        zw_webapp_set_debug_message($post_id, 'Not pushed - Post not published or is in trash');
-        return;
-    }
-    if (get_post_meta($post_id, 'push_sent', true)) {
-        zw_webapp_set_debug_message($post_id, 'Not pushed - Push already sent');
-        return;
-    }
+	if ( 'post' !== $post->post_type ) {
+		zw_webapp_set_debug_message( $post_id, 'Not pushed - Not a post' );
+		return;
+	}
+	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+		zw_webapp_set_debug_message( $post_id, 'Not pushed - Doing autosave' );
+		return;
+	}
+	if ( 'publish' !== get_post_status( $post_id ) || 'trash' === $post->post_status ) {
+		zw_webapp_set_debug_message( $post_id, 'Not pushed - Post not published or is in trash' );
+		return;
+	}
+	if ( get_post_meta( $post_id, 'push_sent', true ) ) {
+		zw_webapp_set_debug_message( $post_id, 'Not pushed - Push already sent' );
+		return;
+	}
 
-    // Check if a push notification is already scheduled for this post
-    if (wp_next_scheduled('send_push_notification', [$post_id])) {
-        zw_webapp_set_debug_message($post_id, 'Not pushed - Push notification already scheduled for this post');
-        return;
-    }
+	// Check if a push notification is already scheduled for this post.
+	if ( wp_next_scheduled( 'send_push_notification', array( $post_id ) ) ) {
+		zw_webapp_set_debug_message( $post_id, 'Not pushed - Push notification already scheduled for this post' );
+		return;
+	}
 
-    wp_schedule_single_event(time(), 'send_push_notification', [$post_id]);
-    zw_webapp_set_debug_message($post_id, 'Push notification scheduled');
-}
-
-function zw_webapp_get_featured_image_url(int $post_id): ?string
-{
-    $thumbnail_id = get_post_thumbnail_id($post_id);
-    if (!$thumbnail_id) {
-        return null;
-    }
-
-    $image_url = wp_get_attachment_image_url($thumbnail_id, 'large');
-    if (!$image_url) {
-        $image_url = wp_get_attachment_image_url($thumbnail_id, 'full');
-    }
-
-    return $image_url;
-}
-
-function zw_webapp_call_api(int $post_id): void
-{
-    $title = apply_filters('zw_webapp_title', 'Nieuws', $post_id);
-
-    $image_url = zw_webapp_get_featured_image_url($post_id);
-
-    // Append the UTM source parameter to the URL
-    $base_url = get_permalink($post_id);
-    $utm_url = add_query_arg('utm_source', 'push', $base_url);
-
-    $body_content = [
-        'recipients' => ['users' => 'all'],
-        'url' => $utm_url,
-        'title' => $title,
-        'body' => html_entity_decode(get_post($post_id)->post_title),
-    ];
-
-    if ($image_url) {
-        $body_content['image'] = $image_url;
-    }
-
-    $response = wp_remote_post('https://progressier.app/' . get_option('zw_webapp_settings')['progressier_id'] . '/send', [
-        'headers' => [
-            'Authorization' => 'Bearer ' . get_option('zw_webapp_settings')['auth_token'],
-            'Content-Type' => 'application/json',
-        ],
-        'body' => json_encode($body_content)
-    ]);
-
-    if (is_wp_error($response)) {
-        zw_webapp_set_debug_message($post_id, 'Error sending push: ' . $response->get_error_message());
-        return;
-    }
-
-    $response_code = wp_remote_retrieve_response_code($response);
-    $response_body = wp_remote_retrieve_body($response);
-
-    if ($response_code !== 200) {
-        zw_webapp_set_debug_message($post_id, 'Error sending push: ' . $response_code . ' - ' . $response_body);
-        return;
-    }
-
-    update_post_meta($post_id, 'push_sent', true);
-    zw_webapp_invalidate_push_count_cache();
-    zw_webapp_set_debug_message($post_id, 'Push sent successfully');
-}
-
-function zw_webapp_set_debug_message(int $post_id, string $message): void
-{
-    $options = get_option('zw_webapp_settings');
-    if (!isset($options['show_push_debug']) || !$options['show_push_debug']) {
-        return;
-    }
-
-    add_post_meta($post_id, 'zw_webapp_debug_msg', $message);
-}
-
-function zw_webapp_show_debug_message(WP_Post $post): void
-{
-    $messages = get_post_meta($post->ID, 'zw_webapp_debug_msg');
-    if ($messages) {
-        ?>
-        <div class="notice notice-info">
-            <p>
-            <?php
-            foreach ($messages as $index => $message) {
-                if ($index > 0) {
-                    echo '<br />';
-                }
-                echo esc_html($message);
-            }
-            ?>
-            </p>
-        </div>
-        <?php
-        delete_post_meta($post->ID, 'zw_webapp_debug_msg');
-    }
+	wp_schedule_single_event( time(), 'send_push_notification', array( $post_id ) );
+	zw_webapp_set_debug_message( $post_id, 'Push notification scheduled' );
 }
 
 /**
- * @return array<string, int>
+ * Returns the URL of the post's featured image, falling back to full size when needed.
+ *
+ * @param int $post_id Post ID.
+ * @return string|null Image URL, or null when no thumbnail is set.
  */
-function zw_webapp_get_daily_push_count(): array
-{
-    global $wpdb;
-    $cache_key = 'zw_webapp_daily_push_count';
-    $daily_push_count = wp_cache_get($cache_key);
+function zw_webapp_get_featured_image_url( int $post_id ): ?string {
+	$thumbnail_id = get_post_thumbnail_id( $post_id );
+	if ( ! $thumbnail_id ) {
+		return null;
+	}
 
-    if ($daily_push_count === false) {
-        // Use a single direct SQL query instead of 7 separate WP_Query calls
-        $results = $wpdb->get_results(
-            $wpdb->prepare(
-                'SELECT
+	$image_url = wp_get_attachment_image_url( $thumbnail_id, 'large' );
+	if ( ! $image_url ) {
+		$image_url = wp_get_attachment_image_url( $thumbnail_id, 'full' );
+	}
+
+	return $image_url;
+}
+
+/**
+ * Sends the push notification request to the Progressier API.
+ *
+ * @param int $post_id Post ID.
+ * @return void
+ */
+function zw_webapp_call_api( int $post_id ): void {
+	$title = apply_filters( 'zw_webapp_title', 'Nieuws', $post_id );
+
+	$image_url = zw_webapp_get_featured_image_url( $post_id );
+
+	// Append the UTM source parameter to the URL.
+	$base_url = get_permalink( $post_id );
+	$utm_url  = add_query_arg( 'utm_source', 'push', $base_url );
+
+	$body_content = array(
+		'recipients' => array( 'users' => 'all' ),
+		'url'        => $utm_url,
+		'title'      => $title,
+		'body'       => html_entity_decode( get_post( $post_id )->post_title ),
+	);
+
+	if ( $image_url ) {
+		$body_content['image'] = $image_url;
+	}
+
+	$response = wp_remote_post(
+		'https://progressier.app/' . get_option( 'zw_webapp_settings' )['progressier_id'] . '/send',
+		array(
+			'headers' => array(
+				'Authorization' => 'Bearer ' . get_option( 'zw_webapp_settings' )['auth_token'],
+				'Content-Type'  => 'application/json',
+			),
+			'body'    => wp_json_encode( $body_content ),
+		)
+	);
+
+	if ( is_wp_error( $response ) ) {
+		zw_webapp_set_debug_message( $post_id, 'Error sending push: ' . $response->get_error_message() );
+		return;
+	}
+
+	$response_code = wp_remote_retrieve_response_code( $response );
+	$response_body = wp_remote_retrieve_body( $response );
+
+	if ( 200 !== $response_code ) {
+		zw_webapp_set_debug_message( $post_id, 'Error sending push: ' . $response_code . ' - ' . $response_body );
+		return;
+	}
+
+	update_post_meta( $post_id, 'push_sent', true );
+	zw_webapp_invalidate_push_count_cache();
+	zw_webapp_set_debug_message( $post_id, 'Push sent successfully' );
+}
+
+/**
+ * Records a debug message on the post when push debug is enabled.
+ *
+ * @param int    $post_id Post ID.
+ * @param string $message Debug message.
+ * @return void
+ */
+function zw_webapp_set_debug_message( int $post_id, string $message ): void {
+	$options = get_option( 'zw_webapp_settings' );
+	if ( ! isset( $options['show_push_debug'] ) || ! $options['show_push_debug'] ) {
+		return;
+	}
+
+	add_post_meta( $post_id, 'zw_webapp_debug_msg', $message );
+}
+
+/**
+ * Renders accumulated push debug messages above the post editor.
+ *
+ * @param WP_Post $post Post object.
+ * @return void
+ */
+function zw_webapp_show_debug_message( WP_Post $post ): void {
+	$messages = get_post_meta( $post->ID, 'zw_webapp_debug_msg', false );
+	if ( $messages ) {
+		?>
+		<div class="notice notice-info">
+			<p>
+			<?php
+			foreach ( $messages as $index => $message ) {
+				if ( $index > 0 ) {
+					echo '<br />';
+				}
+				echo esc_html( $message );
+			}
+			?>
+			</p>
+		</div>
+		<?php
+		delete_post_meta( $post->ID, 'zw_webapp_debug_msg' );
+	}
+}
+
+/**
+ * Returns push counts per day for the last seven days, cached for an hour.
+ *
+ * @return array<string, int> Map of date (Y-m-d) => count.
+ */
+function zw_webapp_get_daily_push_count(): array {
+	global $wpdb;
+	$cache_key        = 'zw_webapp_daily_push_count';
+	$daily_push_count = wp_cache_get( $cache_key );
+
+	if ( false === $daily_push_count ) {
+		// Use a single direct SQL query instead of 7 separate WP_Query calls.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Aggregated dashboard widget query, cached via wp_cache_set just below.
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT
                     DATE(p.post_date) as push_date,
                     COUNT(*) as count
                 FROM
@@ -170,39 +209,43 @@ function zw_webapp_get_daily_push_count(): array
                     DATE(p.post_date)
                 ORDER BY
                     push_date DESC',
-                'push_sent',
-                '1',
-                'post',
-                'publish'
-            )
-        );
+				'push_sent',
+				'1',
+				'post',
+				'publish'
+			)
+		);
 
-        // Initialize counts for all 7 days (today + 6 previous days)
-        $daily_push_count = array();
-        for ($i = 0; $i <= 6; $i++) {
-            $date = date('Y-m-d', strtotime('-' . $i . ' days'));
-            $daily_push_count[$date] = 0;
-        }
+		// Initialise counts for all 7 days (today + 6 previous days).
+		$daily_push_count = array();
+		for ( $i = 0; $i <= 6; $i++ ) {
+			$date                      = gmdate( 'Y-m-d', strtotime( '-' . $i . ' days' ) );
+			$daily_push_count[ $date ] = 0;
+		}
 
-        // Fill in actual counts from query results
-        if ($results) {
-            foreach ($results as $row) {
-                $daily_push_count[$row->push_date] = (int) $row->count;
-            }
-        }
+		// Fill in actual counts from query results.
+		if ( $results ) {
+			foreach ( $results as $row ) {
+				$daily_push_count[ $row->push_date ] = (int) $row->count;
+			}
+		}
 
-        // Sort by date (newest first)
-        krsort($daily_push_count);
+		// Sort by date (newest first).
+		krsort( $daily_push_count );
 
-        // Cache for one hour
-        wp_cache_set($cache_key, $daily_push_count, '', HOUR_IN_SECONDS);
-    }
+		// Cache for one hour.
+		wp_cache_set( $cache_key, $daily_push_count, '', HOUR_IN_SECONDS );
+	}
 
-    return $daily_push_count;
+	return $daily_push_count;
 }
 
-function zw_webapp_invalidate_push_count_cache(): void
-{
-    $cache_key = 'zw_webapp_daily_push_count';
-    wp_cache_delete($cache_key);
+/**
+ * Invalidates the daily-push-count cache so the dashboard reflects fresh data.
+ *
+ * @return void
+ */
+function zw_webapp_invalidate_push_count_cache(): void {
+	$cache_key = 'zw_webapp_daily_push_count';
+	wp_cache_delete( $cache_key );
 }

--- a/zw-webapp.php
+++ b/zw-webapp.php
@@ -1,18 +1,19 @@
 <?php
-
 /**
  * Plugin Name: ZuidWest Webapp
- * Description: Integrates Progressier PWA
- * Version: 2.1.3
- * Author: Streekomroep ZuidWest
- * Author URI: https://www.zuidwesttv.nl
- * License: GPL-2.0-or-later
+ * Description: Integrates Progressier PWA.
+ * Version:     2.1.3
+ * Author:      Streekomroep ZuidWest
+ * Author URI:  https://www.zuidwesttv.nl
+ * License:     GPL-2.0-or-later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * @package ZuidWestWebapp
  */
 
-defined('ABSPATH') || exit;
+defined( 'ABSPATH' ) || exit;
 
-require_once plugin_dir_path(__FILE__) . 'frontend.php';
-require_once plugin_dir_path(__FILE__) . 'push.php';
-require_once plugin_dir_path(__FILE__) . 'options.php';
-require_once plugin_dir_path(__FILE__) . 'dashboard.php';
+require_once plugin_dir_path( __FILE__ ) . 'frontend.php';
+require_once plugin_dir_path( __FILE__ ) . 'push.php';
+require_once plugin_dir_path( __FILE__ ) . 'options.php';
+require_once plugin_dir_path( __FILE__ ) . 'dashboard.php';


### PR DESCRIPTION
Aligns this plugin's phpcs config with the shared baseline shipped in oszuidwest/.github-templates@v2.2.5 (`config-templates/phpcs.xml.dist`) and reformats the PHP files for WordPress-Extra coding standards.

## What changed

- **`phpcs.xml.dist`** — replaces the legacy PSR12 ruleset with the canonical baseline (WordPress-Extra + WordPress-Docs + PHPCompatibilityWP). Per-plugin specifics: file globs, `text_domain: zw-webapp`, prefix rule (`zw_webapp`, `ZW_WEBAPP`).
- **All 5 PHP files** reformatted via `vendor/bin/phpcbf` plus manual fixes:
  - Tab indentation, spaces inside parens, Yoda conditions
  - File-level docblocks with `@package ZuidWestWebapp`
  - Function docblocks with `@param`/`@return`
  - Inline comments end with punctuation
  - `json_encode()` → `wp_json_encode()` (push.php)
  - `get_post_meta()` explicit `$single` argument (push.php)
  - `gmdate()` instead of timezone-dependent `date()` (push.php)
  - Direct DB query in push-count aggregation marked `phpcs:ignore` with rationale (cached via `wp_cache_set` below)

## Functional changes

None intended. Verified line-by-line that hooks, option keys, post meta keys, cron event names, DB query semantics and shortcode handlers are unchanged.

## Test plan

- [ ] CI passes on this PR — phpcs reports 0 errors, 1 warning (a long inline-CSS line in dashboard.php; warnings annotate but don't fail under v2.2.5).