### PR TITLE
chore: require WordPress 7.0

### DIFF
--- a/zw-webapp.php
+++ b/zw-webapp.php
@@ -3,6 +3,8 @@
  * Plugin Name: ZuidWest Webapp
  * Description: Integrates Progressier PWA.
  * Version:     2.1.3
+ * Requires at least: 7.0
+ * Requires PHP: 8.3
  * Author:      Streekomroep ZuidWest
  * Author URI:  https://www.zuidwesttv.nl
  * License:     GPL-2.0-or-later


### PR DESCRIPTION
## Summary

- Declare WordPress 7.0 and PHP 8.3 as the supported runtime baseline.

## Compatibility audit

- Reviewed the WordPress 6.7, 6.8, 6.9, and 7.0 developer field guides, including the current WordPress 7.0.2 maintenance release.
- Checked the plugin's WordPress API calls against Core functions removed or deprecated through 7.0.
- Ran Plugin Check 2.0.0 in update mode and reviewed the findings for runtime relevance.
- Activated the plugin alongside the complete oszuidwest plugin set on WordPress 7.0.2 and PHP 8.3.32.

The audit found no additional WordPress 7 code changes required.

## Verification

- PHPStan
- PHP syntax check
- Plugin Check 2.0.0 review
- Full-set activation on WordPress 7.0.2 / PHP 8.3.32

## References

- [WordPress 6.7 field guide](https://make.wordpress.org/core/2024/10/23/wordpress-6-7-field-guide/)
- [WordPress 6.8 field guide](https://make.wordpress.org/core/2025/03/28/wordpress-6-8-field-guide/)
- [WordPress 6.9 field guide](https://make.wordpress.org/core/2025/11/25/wordpress-6-9-field-guide/)
- [WordPress 7.0 field guide](https://make.wordpress.org/core/2026/05/14/wordpress-7-0-field-guide/)
- [WordPress 7.0.2 release](https://wordpress.org/news/2026/07/wordpress-7-0-2-release/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum required PHP version to 8.3.
  * Declared WordPress 7.0 as the minimum supported version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->